### PR TITLE
Fix AIS static data dimensions

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,9 @@ const {
   buildAisMessage18,
   buildAisMessage24A,
   buildAisMessage24B,
+  hasUsefulAisMessage5Data,
+  hasUsefulAisMessage24AData,
+  hasUsefulAisMessage24BData,
   isDataFresh,
 } = require('./lib/helpers');
 
@@ -149,15 +152,27 @@ module.exports = function createPlugin(app) {
         if (data.aisClass === 'A') {
           app.debug(`Class A, MMSI: ${data.mmsi}, Name: ${data.shipName || 'Unknown'}`);
           aisOut(buildAisMessage3(data, isOwn));
-          aisOut(buildAisMessage5(data, isOwn));
+          if (hasUsefulAisMessage5Data(data)) {
+            aisOut(buildAisMessage5(data, isOwn));
+          } else {
+            app.debug(`Skipping empty AIS message type 5 for MMSI: ${data.mmsi}`);
+          }
           processedCount++;
         }
 
         if (data.aisClass === 'B') {
           app.debug(`Class B, MMSI: ${data.mmsi}, Name: ${data.shipName || 'Unknown'}`);
           aisOut(buildAisMessage18(data, isOwn));
-          aisOut(buildAisMessage24A(data, isOwn));
-          aisOut(buildAisMessage24B(data, isOwn));
+          if (hasUsefulAisMessage24AData(data)) {
+            aisOut(buildAisMessage24A(data, isOwn));
+          } else {
+            app.debug(`Skipping empty AIS message type 24A for MMSI: ${data.mmsi}`);
+          }
+          if (hasUsefulAisMessage24BData(data)) {
+            aisOut(buildAisMessage24B(data, isOwn));
+          } else {
+            app.debug(`Skipping empty AIS message type 24B for MMSI: ${data.mmsi}`);
+          }
           processedCount++;
         }
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -226,6 +226,7 @@ function hasUsefulAisMessage5Data(data) {
   return hasText(data.shipName)
     || hasText(data.callSign)
     || hasText(data.imo)
+    || isPositiveNumber(data.imo)
     || hasText(data.dst)
     || isPositiveNumber(data.id)
     || isPositiveNumber(data.draftCur)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -50,7 +50,19 @@ function getValue(obj, path) {
 
   for (const part of parts) {
     if (current === undefined || current === null) return null;
-    current = current[part];
+    if (current[part] !== undefined) {
+      current = current[part];
+    } else if (
+      typeof current === 'object'
+      && current.value !== undefined
+      && current.value !== null
+      && typeof current.value === 'object'
+      && current.value[part] !== undefined
+    ) {
+      current = current.value[part];
+    } else {
+      return null;
+    }
   }
 
   if (current === undefined || current === null) return null;
@@ -150,6 +162,53 @@ function getNavStatus(state) {
   return stateMapping[state] !== undefined ? stateMapping[state] : '';
 }
 
+function getFirstValue(obj, paths) {
+  for (const path of paths) {
+    const value = getValue(obj, path);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function toFiniteNumber(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const number = Number(value);
+  return Number.isFinite(number) ? number : null;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function calculateDimensions(length, beam, fromBow, fromCenter) {
+  const dimensions = {
+    dimA: 0,
+    dimB: 0,
+    dimC: 0,
+    dimD: 0,
+  };
+
+  const vesselLength = toFiniteNumber(length);
+  if (vesselLength !== null && vesselLength > 0) {
+    const totalLength = clamp(Math.round(vesselLength), 0, 1022);
+    const antennaFromBow = toFiniteNumber(fromBow);
+    const dimA = antennaFromBow !== null ? Math.round(antennaFromBow) : Math.round(totalLength / 2);
+    dimensions.dimA = clamp(dimA, 0, Math.min(totalLength, 511));
+    dimensions.dimB = clamp(totalLength - dimensions.dimA, 0, 511);
+  }
+
+  const vesselBeam = toFiniteNumber(beam);
+  if (vesselBeam !== null && vesselBeam > 0) {
+    const totalBeam = clamp(Math.round(vesselBeam), 0, 126);
+    const antennaFromCenter = toFiniteNumber(fromCenter) || 0;
+    const dimC = Math.round((vesselBeam / 2) + antennaFromCenter);
+    dimensions.dimC = clamp(dimC, 0, Math.min(totalBeam, 63));
+    dimensions.dimD = clamp(totalBeam - dimensions.dimC, 0, 63);
+  }
+
+  return dimensions;
+}
+
 /**
  * Extract vessel data from SignalK vessel object
  * @param {object} vessel - SignalK vessel object
@@ -191,11 +250,16 @@ function extractVesselData(vessel) {
   if (type === null || typeof type === 'number') type = '';
 
   // Draft in meters - ggencoder handles conversion to 0.1m units internally
-  const draftCur = getValue(vessel, 'design.draft.current');
+  const draftCur = getFirstValue(vessel, [
+    'design.draft.current',
+    'design.draft.maximum',
+  ]);
 
   const length = getValue(vessel, 'design.length.overall');
-  let beam = getValue(vessel, 'design.beam');
-  if (beam !== null) beam /= 2;
+  const beam = getValue(vessel, 'design.beam');
+  const fromBow = getValue(vessel, 'sensors.ais.fromBow');
+  const fromCenter = getValue(vessel, 'sensors.ais.fromCenter');
+  const dimensions = calculateDimensions(length, beam, fromBow, fromCenter);
 
   const aisClass = getValue(vessel, 'sensors.ais.class');
 
@@ -217,6 +281,12 @@ function extractVesselData(vessel) {
     draftCur,
     length,
     beam,
+    fromBow,
+    fromCenter,
+    dimA: dimensions.dimA,
+    dimB: dimensions.dimB,
+    dimC: dimensions.dimC,
+    dimD: dimensions.dimD,
     aisClass,
   };
 }
@@ -250,6 +320,10 @@ function buildAisMessage3(data, isOwn = false) {
  * @returns {object} AIS message object
  */
 function buildAisMessage5(data, isOwn = false) {
+  const dimensions = data.dimA !== undefined
+    ? data
+    : calculateDimensions(data.length, data.beam, data.fromBow, data.fromCenter);
+
   return {
     own: isOwn,
     aistype: 5,
@@ -261,10 +335,10 @@ function buildAisMessage5(data, isOwn = false) {
     shipname: data.shipName,
     draught: data.draftCur,
     destination: data.dst,
-    dimA: 0,
-    dimB: data.length,
-    dimC: data.beam,
-    dimD: data.beam,
+    dimA: dimensions.dimA,
+    dimB: dimensions.dimB,
+    dimC: dimensions.dimC,
+    dimD: dimensions.dimD,
   };
 }
 
@@ -313,6 +387,10 @@ function buildAisMessage24A(data, isOwn = false) {
  * @returns {object} AIS message object
  */
 function buildAisMessage24B(data, isOwn = false) {
+  const dimensions = data.dimA !== undefined
+    ? data
+    : calculateDimensions(data.length, data.beam, data.fromBow, data.fromCenter);
+
   return {
     own: isOwn,
     aistype: 24,
@@ -321,10 +399,10 @@ function buildAisMessage24B(data, isOwn = false) {
     mmsi: data.mmsi,
     cargo: data.id,
     callsign: data.callSign,
-    dimA: 0,
-    dimB: data.length,
-    dimC: data.beam,
-    dimD: data.beam,
+    dimA: dimensions.dimA,
+    dimB: dimensions.dimB,
+    dimC: dimensions.dimC,
+    dimD: dimensions.dimD,
   };
 }
 
@@ -349,6 +427,7 @@ module.exports = {
   toHexString,
   createTagBlock,
   getNavStatus,
+  calculateDimensions,
   extractVesselData,
   buildAisMessage3,
   buildAisMessage5,

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -209,6 +209,39 @@ function calculateDimensions(length, beam, fromBow, fromCenter) {
   return dimensions;
 }
 
+function hasText(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isPositiveNumber(value) {
+  const number = toFiniteNumber(value);
+  return number !== null && number > 0;
+}
+
+function hasDimensions(data) {
+  return ['dimA', 'dimB', 'dimC', 'dimD'].some((path) => isPositiveNumber(data[path]));
+}
+
+function hasUsefulAisMessage5Data(data) {
+  return hasText(data.shipName)
+    || hasText(data.callSign)
+    || hasText(data.imo)
+    || hasText(data.dst)
+    || isPositiveNumber(data.id)
+    || isPositiveNumber(data.draftCur)
+    || hasDimensions(data);
+}
+
+function hasUsefulAisMessage24AData(data) {
+  return hasText(data.shipName);
+}
+
+function hasUsefulAisMessage24BData(data) {
+  return hasText(data.callSign)
+    || isPositiveNumber(data.id)
+    || hasDimensions(data);
+}
+
 /**
  * Extract vessel data from SignalK vessel object
  * @param {object} vessel - SignalK vessel object
@@ -428,6 +461,9 @@ module.exports = {
   createTagBlock,
   getNavStatus,
   calculateDimensions,
+  hasUsefulAisMessage5Data,
+  hasUsefulAisMessage24AData,
+  hasUsefulAisMessage24BData,
   extractVesselData,
   buildAisMessage3,
   buildAisMessage5,

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -8,6 +8,7 @@ const {
   toHexString,
   createTagBlock,
   getNavStatus,
+  calculateDimensions,
   extractVesselData,
   buildAisMessage3,
   buildAisMessage5,
@@ -56,6 +57,28 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
         }
       }
       assert.strictEqual(getValue(obj, 'navigation.speedOverGround'), 5.5)
+    })
+
+    it('extracts nested values inside SignalK value wrappers', function () {
+      const obj = {
+        design: {
+          length: {
+            value: {
+              overall: 11.72
+            }
+          },
+          aisShipType: {
+            value: {
+              id: 36,
+              name: 'Sailing'
+            }
+          }
+        }
+      }
+
+      assert.strictEqual(getValue(obj, 'design.length.overall'), 11.72)
+      assert.strictEqual(getValue(obj, 'design.aisShipType.id'), 36)
+      assert.strictEqual(getValue(obj, 'design.aisShipType.name'), 'Sailing')
     })
 
     it('returns null for non-existent path', function () {
@@ -386,7 +409,7 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
       assert.strictEqual(data.imo, '9876543')
     })
 
-    it('handles beam division by 2', function () {
+    it('extracts beam as the full vessel beam', function () {
       const vessel = {
         mmsi: '123456789',
         design: {
@@ -395,7 +418,7 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
       }
 
       const data = extractVesselData(vessel)
-      assert.strictEqual(data.beam, 5)
+      assert.strictEqual(data.beam, 10)
     })
 
     it('handles draft in meters (no division)', function () {
@@ -411,6 +434,110 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
       const data = extractVesselData(vessel)
       // Draft is passed through as-is in meters - ggencoder handles conversion
       assert.strictEqual(data.draftCur, 3.5)
+    })
+
+    it('extracts dimensions and AIS type from SignalK value objects', function () {
+      const vessel = {
+        mmsi: '227406160',
+        name: 'TANAGRA IV',
+        design: {
+          length: { value: { overall: 11.72 } },
+          beam: { value: 3.93 },
+          draft: { value: { current: 1.8 } },
+          aisShipType: { value: { id: 36, name: 'Sailing' } }
+        },
+        sensors: {
+          ais: {
+            fromBow: { value: 6 },
+            fromCenter: { value: 0 },
+            class: { value: 'B' }
+          }
+        }
+      }
+
+      const data = extractVesselData(vessel)
+
+      assert.strictEqual(data.length, 11.72)
+      assert.strictEqual(data.beam, 3.93)
+      assert.strictEqual(data.id, 36)
+      assert.strictEqual(data.type, 'Sailing')
+      assert.strictEqual(data.draftCur, 1.8)
+      assert.strictEqual(data.fromBow, 6)
+      assert.strictEqual(data.fromCenter, 0)
+      assert.strictEqual(data.dimA, 6)
+      assert.strictEqual(data.dimB, 6)
+      assert.strictEqual(data.dimC, 2)
+      assert.strictEqual(data.dimD, 2)
+    })
+
+    it('centers AIS dimensions when AIS antenna offsets are missing', function () {
+      const vessel = {
+        mmsi: '123456789',
+        design: {
+          length: { value: { overall: 20 } },
+          beam: { value: 6 }
+        }
+      }
+
+      const data = extractVesselData(vessel)
+
+      assert.strictEqual(data.fromBow, null)
+      assert.strictEqual(data.fromCenter, null)
+      assert.strictEqual(data.dimA, 10)
+      assert.strictEqual(data.dimB, 10)
+      assert.strictEqual(data.dimC, 3)
+      assert.strictEqual(data.dimD, 3)
+    })
+
+    it('falls back to maximum draft when current draft is missing', function () {
+      const vessel = {
+        mmsi: '123456789',
+        design: {
+          draft: {
+            value: {
+              maximum: 2
+            }
+          }
+        }
+      }
+
+      const data = extractVesselData(vessel)
+      assert.strictEqual(data.draftCur, 2)
+    })
+  })
+
+  describe('calculateDimensions', function () {
+    it('uses antenna offsets from bow and centerline', function () {
+      assert.deepStrictEqual(calculateDimensions(171, 28, 44, 0), {
+        dimA: 44,
+        dimB: 127,
+        dimC: 14,
+        dimD: 14
+      })
+    })
+
+    it('handles starboard and port center offsets', function () {
+      assert.deepStrictEqual(calculateDimensions(52, 8, 18, 3), {
+        dimA: 18,
+        dimB: 34,
+        dimC: 7,
+        dimD: 1
+      })
+      assert.deepStrictEqual(calculateDimensions(31, 6, 8, -1), {
+        dimA: 8,
+        dimB: 23,
+        dimC: 2,
+        dimD: 4
+      })
+    })
+
+    it('centers dimensions when antenna offsets are missing', function () {
+      assert.deepStrictEqual(calculateDimensions(12, 4, null, null), {
+        dimA: 6,
+        dimB: 6,
+        dimC: 2,
+        dimD: 2
+      })
     })
   })
 
@@ -482,10 +609,10 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
       assert.strictEqual(msg.shipname, 'Test Ship')
       assert.strictEqual(msg.draught, 3.5)
       assert.strictEqual(msg.destination, 'Helsinki')
-      assert.strictEqual(msg.dimA, 0)
-      assert.strictEqual(msg.dimB, 50)
-      assert.strictEqual(msg.dimC, 8)
-      assert.strictEqual(msg.dimD, 8)
+      assert.strictEqual(msg.dimA, 25)
+      assert.strictEqual(msg.dimB, 25)
+      assert.strictEqual(msg.dimC, 4)
+      assert.strictEqual(msg.dimD, 4)
     })
   })
 
@@ -566,10 +693,10 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
       assert.strictEqual(msg.mmsi, '123456789')
       assert.strictEqual(msg.cargo, 36)
       assert.strictEqual(msg.callsign, 'XYZ')
-      assert.strictEqual(msg.dimA, 0)
-      assert.strictEqual(msg.dimB, 12)
-      assert.strictEqual(msg.dimC, 4)
-      assert.strictEqual(msg.dimD, 4)
+      assert.strictEqual(msg.dimA, 6)
+      assert.strictEqual(msg.dimB, 6)
+      assert.strictEqual(msg.dimC, 2)
+      assert.strictEqual(msg.dimD, 2)
     })
   })
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -9,6 +9,9 @@ const {
   createTagBlock,
   getNavStatus,
   calculateDimensions,
+  hasUsefulAisMessage5Data,
+  hasUsefulAisMessage24AData,
+  hasUsefulAisMessage24BData,
   extractVesselData,
   buildAisMessage3,
   buildAisMessage5,
@@ -538,6 +541,55 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
         dimC: 2,
         dimD: 2
       })
+    })
+  })
+
+  describe('static AIS message usefulness', function () {
+    it('rejects empty Class A static data', function () {
+      assert.strictEqual(hasUsefulAisMessage5Data({
+        shipName: '',
+        callSign: '',
+        imo: '',
+        id: null,
+        draftCur: null,
+        dst: '',
+        dimA: 0,
+        dimB: 0,
+        dimC: 0,
+        dimD: 0
+      }), false)
+    })
+
+    it('accepts Class A static data with any useful field', function () {
+      assert.strictEqual(hasUsefulAisMessage5Data({ shipName: 'TEST' }), true)
+      assert.strictEqual(hasUsefulAisMessage5Data({ callSign: 'ABCD' }), true)
+      assert.strictEqual(hasUsefulAisMessage5Data({ imo: '9876543' }), true)
+      assert.strictEqual(hasUsefulAisMessage5Data({ id: 70 }), true)
+      assert.strictEqual(hasUsefulAisMessage5Data({ draftCur: 3.5 }), true)
+      assert.strictEqual(hasUsefulAisMessage5Data({ dst: 'Helsinki' }), true)
+      assert.strictEqual(hasUsefulAisMessage5Data({ dimA: 1 }), true)
+    })
+
+    it('requires a ship name for Class B static part A', function () {
+      assert.strictEqual(hasUsefulAisMessage24AData({ shipName: '' }), false)
+      assert.strictEqual(hasUsefulAisMessage24AData({ shipName: 'TEST' }), true)
+    })
+
+    it('rejects empty Class B static part B data', function () {
+      assert.strictEqual(hasUsefulAisMessage24BData({
+        callSign: '',
+        id: null,
+        dimA: 0,
+        dimB: 0,
+        dimC: 0,
+        dimD: 0
+      }), false)
+    })
+
+    it('accepts Class B static part B data with any useful field', function () {
+      assert.strictEqual(hasUsefulAisMessage24BData({ callSign: 'XYZ' }), true)
+      assert.strictEqual(hasUsefulAisMessage24BData({ id: 36 }), true)
+      assert.strictEqual(hasUsefulAisMessage24BData({ dimC: 2 }), true)
     })
   })
 

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -564,6 +564,7 @@ describe('signalk-vessels-to-ais-ws helpers', function () {
       assert.strictEqual(hasUsefulAisMessage5Data({ shipName: 'TEST' }), true)
       assert.strictEqual(hasUsefulAisMessage5Data({ callSign: 'ABCD' }), true)
       assert.strictEqual(hasUsefulAisMessage5Data({ imo: '9876543' }), true)
+      assert.strictEqual(hasUsefulAisMessage5Data({ imo: 9876543 }), true)
       assert.strictEqual(hasUsefulAisMessage5Data({ id: 70 }), true)
       assert.strictEqual(hasUsefulAisMessage5Data({ draftCur: 3.5 }), true)
       assert.strictEqual(hasUsefulAisMessage5Data({ dst: 'Helsinki' }), true)

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -110,14 +110,21 @@ describe('signalk-vessels-to-ais-ws plugin integration', function () {
       },
       sensors: {
         ais: {
-          class: { value: options.aisClass || 'A' }
+          class: { value: options.aisClass || 'A' },
+          fromBow: { value: options.fromBow !== undefined ? options.fromBow : 8 },
+          fromCenter: { value: options.fromCenter !== undefined ? options.fromCenter : 0 }
         }
       },
       design: {
-        length: { overall: { value: options.length || 15 } },
-        beam: { value: options.beam || 5 },
-        draft: { current: { value: options.draft || 2 } },
-        aisShipType: { id: { value: options.shipType || 36 } }
+        length: { value: { overall: options.length !== undefined ? options.length : 15 } },
+        beam: { value: options.beam !== undefined ? options.beam : 5 },
+        draft: { value: { current: options.draft !== undefined ? options.draft : 2 } },
+        aisShipType: {
+          value: {
+            id: options.shipType !== undefined ? options.shipType : 36,
+            name: 'Sailing'
+          }
+        }
       },
       communication: {
         callsignVhf: { value: options.callsign || 'TEST1' }


### PR DESCRIPTION
## Summary

- read nested Signal K static values such as `design.length.value.overall` and `design.aisShipType.value.id`
- compute AIS dimensions from `sensors.ais.fromBow` and `sensors.ais.fromCenter`, with centered fallback when antenna offsets are missing
- skip empty AIS static messages at startup while continuing to publish position reports

## Root Cause

After the direct `app.getPath('vessels')` refactor, static values wrapped in Signal K `value` objects were not read when the useful field was nested inside that wrapper. This produced AIS static messages with zero length, zero ship type, and sometimes empty names/callsigns.

## Validation

- `npm test`
- `npm run lint`
- live Signal K / NMEA TCP test with TZ iBoat confirming vessel dimensions are displayed
- live capture after filtering showed no empty AIS static records
